### PR TITLE
Fix the GitHub Actions tag pattern

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]$"
+      - "v[0-9]+.[0-9]+.[0-9]+"
     paths-ignore:
       - "**/*.md"
       - LICENSE
@@ -248,6 +248,7 @@ jobs:
       INTEGRATIONOS_TESTING_MODEL: ${{ secrets.INTEGRATIONOS_TESTING_MODEL }}
   publish:
     name: Publish
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     needs:
       - test-macOS-windows-binding
@@ -272,7 +273,6 @@ jobs:
         run: ls -R ./npm
         shell: bash
       - name: Publish
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
           npm publish --access public


### PR DESCRIPTION
GitHub Actions branch and tag pattern matching doesn't have full regex support. Documentation on filter patterns can be found here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

Also move the publish conditional from the step to the job.