### PR TITLE
fix: set explicit target to fix missing darwin-x64 package

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
           - host: macos-latest
             target: x86_64-apple-darwin
             build: |
-              yarn build
+              yarn build --target x86_64-apple-darwin
               strip -x *.node
           - host: windows-latest
             build: yarn build
@@ -138,8 +138,10 @@ jobs:
         settings:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
-          - host: macos-latest
+          - host: macos-13
             target: x86_64-apple-darwin
+          - host: macos-latest
+            target: aarch64-apple-darwin
         node:
           - "18"
           - "20"

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@integrationos/node-darwin-arm64",
-  "version": "3.7.6",
+  "version": "3.7.10",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@integrationos/node-darwin-x64",
-  "version": "3.7.6",
+  "version": "3.7.10",
   "os": [
     "darwin"
   ],

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@integrationos/node-linux-arm64-gnu",
-  "version": "3.7.6",
+  "version": "3.7.10",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@integrationos/node-linux-x64-gnu",
-  "version": "3.7.6",
+  "version": "3.7.10",
   "os": [
     "linux"
   ],

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@integrationos/node-win32-arm64-msvc",
-  "version": "3.7.6",
+  "version": "3.7.10",
   "os": [
     "win32"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@integrationos/node-win32-x64-msvc",
-  "version": "3.7.6",
+  "version": "3.7.10",
   "os": [
     "win32"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integrationos/node",
-  "version": "3.7.6",
+  "version": "3.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integrationos/node",
-      "version": "3.7.6",
+      "version": "3.7.10",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@integrationos/node",
-  "version": "3.7.9",
+  "version": "3.7.10",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {


### PR DESCRIPTION
The last published package of [`@integrationos/node-darwin-x64`](https://www.npmjs.com/package/@integrationos/node-darwin-x64) is `3.7.3`, while the other packages are up to `3.7.9`.

The `macos-latest` GitHub Action runner recently switched from Intel to M1 which might explain why this began breaking.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories


For more context see https://github.com/napi-rs/napi-rs/issues/2076